### PR TITLE
Fix: When a file failed to be uploaded then the succesful indexed file seems to be duplicated

### DIFF
--- a/src/pages/wizard/knowledge.tsx
+++ b/src/pages/wizard/knowledge.tsx
@@ -75,6 +75,8 @@ const Knowledge: React.FC<KnowledgeProps> = ({
     try {
       const assistantsService = new AssistantsService();
       const filesFromServer = await assistantsService.getFiles(assistantId);
+      setLocalFiles([]);
+      onFilesChange([]);
       setAllFiles(filesFromServer);
     } catch (error) {
       console.error("Error fetching files:", error);


### PR DESCRIPTION
Fix: When a file failed to be uploaded then the succesful indexed file seems to be duplicated